### PR TITLE
Fix libdb and bsddb3 version

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -37,7 +37,7 @@ outputs:
         - cudatoolkit                       # [linux]
         - cudnn                             # [linux]
         - tensorflow     2.*                # [osx]
-        - bsddb3
+        - bsddb3         6.2.7   
         - pydusa         1.15 *_17           # [not win]
         - nose
         - future
@@ -61,6 +61,7 @@ outputs:
         - jpeg
         - libtiff        4.0.9
         - libpng         1.6.37
+        - libdb          6.1.26
         - zlib
 
 about:

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps-dev
-    version: '24.1'
+    version: '24.2'
 
 build:
     number: 0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,10 +2,10 @@
 
 package:
     name: eman-deps-dev
-    version: '24.2'
+    version: '24.1'
 
 build:
-    number: 0
+    number: 1
     skip: True  # [win32]
 
 requirements:


### PR DESCRIPTION
https://anaconda.org/conda-forge/libdb

libdb changed 20 hours ago to the new version 6.2.32, which is not yet compatible with the latest bsddb3 6.2.7 version.