### PR TITLE
v29

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps
-    version: '29.5'
+    version: '29.6'
 
 build:
     # prioritize gui variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps
-    version: '29.4'
+    version: '29.5'
 
 build:
     # prioritize gui variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
         - tqdm
 
         - python         3.7.*
-        - boost          1.72
+        - boost          1.73
         - fftw           3.3.8  mpi_openmpi_*  # [not win]
         - fftw           3.3.8  nompi_*        # [win]
         - numpy          1.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
         - tqdm
 
         - python         3.7.*
-        - boost          1.69
+        - boost          1.70
         - fftw           3.3.8  mpi_openmpi_*  # [not win]
         - fftw           3.3.8  nompi_*        # [win]
         - numpy          1.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
         - tqdm
 
         - python         3.7.*
-        - boost          1.70
+        - boost          1.71
         - fftw           3.3.8  mpi_openmpi_*  # [not win]
         - fftw           3.3.8  nompi_*        # [win]
         - numpy          1.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps
-    version: '29.0'
+    version: '29.1'
 
 build:
     # prioritize gui variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -34,7 +34,7 @@ requirements:
         - cudnn          7                  # [linux]
         - tensorflow     2.*                # [osx or win]
         - bsddb3         6.2.6
-        - pydusa         1.15 *_17          # [not win]
+        - pydusa         2.1                # [not win]
         - nose
         - future
         - configparser

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps
-    version: '29.1'
+    version: '29.2'
 
 build:
     # prioritize gui variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps
-    version: '28.0'
+    version: '29.0'
 
 build:
     # prioritize gui variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
         - tqdm
 
         - python         3.7.*
-        - boost          1.73
+        - boost          1.74
         - fftw           3.3.8  mpi_openmpi_*  # [not win]
         - fftw           3.3.8  nompi_*        # [win]
         - numpy          1.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps
-    version: '29.3'
+    version: '29.4'
 
 build:
     # prioritize gui variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps
-    version: '29.2'
+    version: '29.3'
 
 build:
     # prioritize gui variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,7 +41,7 @@ requirements:
         - tqdm
 
         - python         3.7.*
-        - boost          1.71
+        - boost          1.72
         - fftw           3.3.8  mpi_openmpi_*  # [not win]
         - fftw           3.3.8  nompi_*        # [win]
         - numpy          1.17

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -2,7 +2,7 @@
 
 package:
     name: eman-deps
-    version: '29.6'
+    version: '29.5'
 
 build:
     # prioritize gui variant via build number

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -41,9 +41,7 @@ requirements:
         - tqdm
 
         - python         3.7.*
-        - boost          1.69.*                # [win]
-        - boost          1.69.* *_0            # [not win]
-        - boost-cpp      1.69.* *_0            # [not win]
+        - boost          1.69
         - fftw           3.3.8  mpi_openmpi_*  # [not win]
         - fftw           3.3.8  nompi_*        # [win]
         - numpy          1.17


### PR DESCRIPTION
`29.0`: pydusa 2.1
`29.1`: boost 1.69
`29.2`: boost 1.70
`29.3`: boost 1.71
`29.4`: boost 1.72
`29.5`: boost 1.73
`29.6`: boost 1.74

`boost 1.74` upgrade doesn't work on osx with `openmpi 3`. `29.6` on anaconda.org has been moved to another label to mark it as broken.
